### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AKA VectorDrawableCompat: A 7+ backport of [VectorDrawable](https://developer.an
 See demo, at this point latest version looks like
 
 ```groovy
-compile 'com.telly:mrvector:0.2.0'
+implementation 'com.telly:mrvector:0.2.0'
 ```
 
 ### Basic inflate


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.